### PR TITLE
[WIP] Fix api blueprint format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+doc
 tmp
 .rvmrc
 .ruby-version

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,7 +57,7 @@ GEM
       multipart-post (>= 1.2, < 3)
     ffi (1.9.10)
     gherkin (3.2.0)
-    hashdiff (0.2.3)
+    hashdiff (0.3.7)
     httpclient (2.7.1)
     i18n (0.7.0)
     inch (0.7.0)
@@ -129,7 +129,7 @@ GEM
     tins (1.8.2)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
-    webmock (1.22.6)
+    webmock (3.3.0)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
@@ -154,7 +154,7 @@ DEPENDENCIES
   rspec_api_documentation!
   sinatra (~> 1.4, >= 1.4.4)
   thin (~> 1.6, >= 1.6.3)
-  webmock (~> 1.7)
+  webmock (~> 3.3)
 
 BUNDLED WITH
    1.16.1

--- a/lib/rspec_api_documentation/configuration.rb
+++ b/lib/rspec_api_documentation/configuration.rb
@@ -81,6 +81,9 @@ module RspecApiDocumentation
     add_setting :response_headers_to_include, :default => nil
     add_setting :html_embedded_css_file, :default => nil
 
+    # sorting
+    add_setting :sort_routes, :default => false
+
     # renamed to request_body_formatter. here for backwards compatibility
     add_setting :post_body_formatter, :default => nil
 

--- a/lib/rspec_api_documentation/dsl/endpoint/params.rb
+++ b/lib/rspec_api_documentation/dsl/endpoint/params.rb
@@ -13,11 +13,19 @@ module RspecApiDocumentation
         end
 
         def call
-          parameters = example.metadata.fetch(:parameters, {}).inject({}) do |hash, param|
+          set_param = -> hash, param {
             SetParam.new(self, hash, param).call
-          end
-          parameters.deep_merge!(extra_params)
-          parameters
+          }
+
+          example.metadata
+            .fetch(:parameters, {})
+            .inject({}, &set_param)
+            .deep_merge(
+              example.metadata
+                .fetch(:attributes, {})
+                .inject({}, &set_param)
+            )
+            .deep_merge(extra_params)
         end
 
       private

--- a/lib/rspec_api_documentation/dsl/resource.rb
+++ b/lib/rspec_api_documentation/dsl/resource.rb
@@ -30,7 +30,7 @@ module RspecApiDocumentation::DSL
 
       def callback(*args, &block)
         begin
-          require 'webmock'
+          require 'webmock/rspec'
         rescue LoadError
           raise "Callbacks require webmock to be installed"
         end

--- a/lib/rspec_api_documentation/dsl/resource.rb
+++ b/lib/rspec_api_documentation/dsl/resource.rb
@@ -8,15 +8,25 @@ module RspecApiDocumentation::DSL
         define_method method do |*args, &block|
           options = args.extract_options!
           options[:method] = method
+
           if metadata[:route_uri]
             options[:route] = metadata[:route_uri]
             options[:action_name] = args.first
+
           else
             options[:route] = args.first
+            options[:route_uri] = args[0].gsub(/\{.*\}/, "")
+            options[:route_optionals] = (optionals = args[0].match(/(\{.*\})/) and optionals[-1])
+            options[:route_name] = options[:route_name] || options[:route]
+            options[:action_name] = options[:action_name] || method.to_s.upcase
+
           end
+
           options[:api_doc_dsl] = :endpoint
+
           args.push(options)
           args[0] = "#{method.to_s.upcase} #{args[0]}"
+
           context(*args, &block)
         end
       end

--- a/lib/rspec_api_documentation/dsl/resource.rb
+++ b/lib/rspec_api_documentation/dsl/resource.rb
@@ -71,7 +71,13 @@ module RspecApiDocumentation::DSL
       end
 
       def explanation(text)
-        safe_metadata(:resource_explanation, text)
+        if metadata[:method].present?
+          safe_metadata(:method_explanation, text)
+        elsif metadata[:route_uri].present?
+          safe_metadata(:route_explanation, text)
+        else
+          safe_metadata(:resource_explanation, text)
+        end
       end
 
       private

--- a/lib/rspec_api_documentation/views/api_blueprint_example.rb
+++ b/lib/rspec_api_documentation/views/api_blueprint_example.rb
@@ -1,7 +1,7 @@
 module RspecApiDocumentation
   module Views
     class ApiBlueprintExample < MarkupExample
-      TOTAL_SPACES_INDENTATION = 8.freeze
+      TOTAL_SPACES_INDENTATION = 12.freeze
 
       def initialize(example, configuration)
         super

--- a/lib/rspec_api_documentation/views/api_blueprint_example.rb
+++ b/lib/rspec_api_documentation/views/api_blueprint_example.rb
@@ -20,14 +20,14 @@ module RspecApiDocumentation
 
       def requests
         super.map do |request|
-          request[:request_headers_text]  = remove_utf8_for_json(request[:request_headers_text])
+          request[:request_headers_text]  = remove_utf8_for_json(remove_content_type(request[:request_headers_text]))
           request[:request_headers_text]  = indent(request[:request_headers_text])
           request[:request_content_type]  = content_type(request[:request_headers])
           request[:request_content_type]  = remove_utf8_for_json(request[:request_content_type])
           request[:request_body]          = body_to_json(request, :request)
           request[:request_body]          = indent(request[:request_body])
 
-          request[:response_headers_text] = remove_utf8_for_json(request[:response_headers_text])
+          request[:response_headers_text] = remove_utf8_for_json(remove_content_type(request[:response_headers_text]))
           request[:response_headers_text] = indent(request[:response_headers_text])
           request[:response_content_type] = content_type(request[:response_headers])
           request[:response_content_type] = remove_utf8_for_json(request[:response_content_type])
@@ -76,6 +76,18 @@ module RspecApiDocumentation
         end
 
         body
+      end
+
+      # `Content-Type` header is removed because the information would be duplicated
+      # since it's already present in `request[:request_content_type]`.
+      def remove_content_type(headers)
+        return unless headers
+        headers
+          .split("\n")
+          .reject { |header|
+            header.start_with?('Content-Type:')
+          }
+          .join("\n")
       end
 
       # JSON requests should use UTF-8 by default according to

--- a/lib/rspec_api_documentation/views/api_blueprint_index.rb
+++ b/lib/rspec_api_documentation/views/api_blueprint_index.rb
@@ -23,7 +23,7 @@ module RspecApiDocumentation
             {
               "has_attributes?".to_sym => attrs.size > 0,
               "has_parameters?".to_sym => params.size > 0,
-              route: route,
+              route: format_route(examples[0]),
               route_name: examples[0][:route_name],
               attributes: attrs,
               parameters: params,
@@ -44,6 +44,17 @@ module RspecApiDocumentation
       end
 
       private
+
+      # APIB follows the RFC 6570 to format URI templates.
+      # According to it, path segment expansion (used to describe URI path
+      # hierarchies) should be represented by `{/var}` and not by `/:var`
+      # For example `/posts/:id` should become `/posts{/id}`
+      # cf. https://github.com/apiaryio/api-blueprint/blob/format-1A/API%20Blueprint%20Specification.md#431-resource-section
+      # cf. https://tools.ietf.org/html/rfc6570#section-3.2.6
+      def format_route(example)
+        route_uri = example[:route_uri].gsub(/\/:(.*?)([.\/?{]|$)/, '{/\1}\2')
+        "#{route_uri}#{example[:route_optionals]}"
+      end
 
       # APIB has both `parameters` and `attributes`. This generates a hash
       # with all of its properties, like name, description, required.

--- a/lib/rspec_api_documentation/views/api_blueprint_index.rb
+++ b/lib/rspec_api_documentation/views/api_blueprint_index.rb
@@ -12,14 +12,18 @@ module RspecApiDocumentation
             attrs  = fields(:attributes, examples)
             params = fields(:parameters, examples)
 
-            methods = examples.group_by(&:http_method).map do |http_method, examples|
-              {
-                http_method: http_method,
-                description: examples.first.try(:action_name),
-                explanation: examples.first.try(:[], :metadata).try(:[], :method_explanation),
-                examples: examples
-              }
-            end
+            methods = examples
+              .group_by { |e| "#{e.http_method} - #{e.action_name}" }
+              .map do |group, examples|
+                first_example = examples.first
+
+                {
+                  http_method: first_example.try(:http_method),
+                  description: first_example.try(:action_name),
+                  explanation: first_example.try(:[], :metadata).try(:[], :method_explanation),
+                  examples: examples
+                }
+              end
 
             {
               "has_attributes?".to_sym => attrs.size > 0,

--- a/lib/rspec_api_documentation/views/api_blueprint_index.rb
+++ b/lib/rspec_api_documentation/views/api_blueprint_index.rb
@@ -46,13 +46,13 @@ module RspecApiDocumentation
       private
 
       # APIB follows the RFC 6570 to format URI templates.
-      # According to it, path segment expansion (used to describe URI path
-      # hierarchies) should be represented by `{/var}` and not by `/:var`
-      # For example `/posts/:id` should become `/posts{/id}`
+      # According to it, simple string expansion (used to perform variable
+      # expansion) should be represented by `{var}` and not by `:var`
+      # For example `/posts/:id` should become `/posts/{id}`
       # cf. https://github.com/apiaryio/api-blueprint/blob/format-1A/API%20Blueprint%20Specification.md#431-resource-section
-      # cf. https://tools.ietf.org/html/rfc6570#section-3.2.6
+      # cf. https://tools.ietf.org/html/rfc6570#section-3.2.2
       def format_route(example)
-        route_uri = example[:route_uri].gsub(/\/:(.*?)([.\/?{]|$)/, '{/\1}\2')
+        route_uri = example[:route_uri].gsub(/:(.*?)([.\/?{]|$)/, '{\1}\2')
         "#{route_uri}#{example[:route_optionals]}"
       end
 

--- a/lib/rspec_api_documentation/views/api_blueprint_index.rb
+++ b/lib/rspec_api_documentation/views/api_blueprint_index.rb
@@ -66,7 +66,7 @@ module RspecApiDocumentation
       #     type: "string",
       #     name: "id",
       #     description: "The id",
-      #     properties_description: "required, string"
+      #     properties_description: "string, required"
       #   }
       def fields(property_name, examples)
         examples
@@ -76,8 +76,10 @@ module RspecApiDocumentation
           .uniq { |property| property[:name] }
           .map do |property|
             properties = []
-            properties << "required"      if property[:required]
             properties << property[:type] if property[:type]
+            properties << "required"      if property[:required] == true
+            properties << "optional"      if property[:required].blank?
+
             if properties.count > 0
               property[:properties_description] = properties.join(", ")
             else

--- a/lib/rspec_api_documentation/views/api_blueprint_index.rb
+++ b/lib/rspec_api_documentation/views/api_blueprint_index.rb
@@ -62,7 +62,6 @@ module RspecApiDocumentation
       # with all of its properties, like name, description, required.
       #   {
       #     required: true,
-      #     example: "1",
       #     type: "string",
       #     name: "id",
       #     description: "The id",

--- a/lib/rspec_api_documentation/views/api_blueprint_index.rb
+++ b/lib/rspec_api_documentation/views/api_blueprint_index.rb
@@ -38,7 +38,7 @@ module RspecApiDocumentation
           end
 
           section.merge({
-            routes: routes
+            routes: @configuration.sort_routes ? routes.sort_by { |r| r[:route_name] } : routes
           })
         end
       end

--- a/lib/rspec_api_documentation/views/api_blueprint_index.rb
+++ b/lib/rspec_api_documentation/views/api_blueprint_index.rb
@@ -16,6 +16,7 @@ module RspecApiDocumentation
               {
                 http_method: http_method,
                 description: examples.first.respond_to?(:action_name) && examples.first.action_name,
+                explanation: examples.first.respond_to?(:method_explanation) && examples.first.method_explanation,
                 examples: examples
               }
             end
@@ -25,6 +26,7 @@ module RspecApiDocumentation
               "has_parameters?".to_sym => params.size > 0,
               route: format_route(examples[0]),
               route_name: examples[0][:route_name],
+              explanation: examples[0][:route_explanation],
               attributes: attrs,
               parameters: params,
               http_methods: methods

--- a/lib/rspec_api_documentation/views/api_blueprint_index.rb
+++ b/lib/rspec_api_documentation/views/api_blueprint_index.rb
@@ -15,8 +15,8 @@ module RspecApiDocumentation
             methods = examples.group_by(&:http_method).map do |http_method, examples|
               {
                 http_method: http_method,
-                description: examples.first.respond_to?(:action_name) && examples.first.action_name,
-                explanation: examples.first.respond_to?(:method_explanation) && examples.first.method_explanation,
+                description: examples.first.try(:action_name),
+                explanation: examples.first.try(:[], :metadata).try(:[], :method_explanation),
                 examples: examples
               }
             end

--- a/rspec_api_documentation.gemspec
+++ b/rspec_api_documentation.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rake", "~> 10.1"
   s.add_development_dependency "rack-test", "~> 0.6.2"
   s.add_development_dependency "rack-oauth2", "~> 1.2.2", ">= 1.0.7"
-  s.add_development_dependency "webmock", "~> 1.7"
+  s.add_development_dependency "webmock", "~> 3.3"
   s.add_development_dependency "rspec-its", "~> 1.0"
   s.add_development_dependency "faraday", "~> 0.9", ">= 0.9.0"
   s.add_development_dependency "thin", "~> 1.6", ">= 1.6.3"

--- a/spec/dsl_spec.rb
+++ b/spec/dsl_spec.rb
@@ -130,9 +130,12 @@ resource "Order" do
     parameter :id, 'The ID of the resource.', :required => true, scope: :data
     parameter :note, "Any additional notes about your order."
 
+    attribute :tip, "The amount you want to tip", :required => true
+
     let(:type) { "coffee" }
     let(:size) { "medium" }
     let(:data_id) { 2 }
+    let(:tip) { 20 }
 
     let(:id) { 1 }
 
@@ -155,6 +158,10 @@ resource "Order" do
 
       it 'should set the scoped data ID' do
         expect(params['data']).to eq({'id' => 2})
+      end
+
+      it "should set attributes as well" do
+        expect(params["tip"]).to eq(tip())
       end
 
       it "should allow extra parameters to be passed in" do

--- a/spec/http_test_client_spec.rb
+++ b/spec/http_test_client_spec.rb
@@ -3,7 +3,7 @@ require 'rack/test'
 require 'capybara'
 require 'capybara/server'
 require 'sinatra/base'
-require 'webmock'
+require 'webmock/rspec'
 require 'support/stub_app'
 
 describe RspecApiDocumentation::HttpTestClient do
@@ -16,7 +16,7 @@ describe RspecApiDocumentation::HttpTestClient do
       Rack::Handler::Thin.run(app, :Port => port)
     end
 
-    server = Capybara::Server.new(StubApp.new, 8888)
+    server = Capybara::Server.new(StubApp.new, 29876)
     server.boot
   end
 
@@ -25,7 +25,7 @@ describe RspecApiDocumentation::HttpTestClient do
   end
 
   let(:client_context) { |example| double(example: example, app_root: 'nowhere') }
-  let(:target_host) { 'http://localhost:8888' }
+  let(:target_host) { 'http://localhost:29876' }
   let(:test_client) { RspecApiDocumentation::HttpTestClient.new(client_context, {host: target_host}) }
 
   subject { test_client }

--- a/spec/views/api_blueprint_example_spec.rb
+++ b/spec/views/api_blueprint_example_spec.rb
@@ -57,17 +57,9 @@ describe RspecApiDocumentation::Views::ApiBlueprintExample do
     describe 'request_headers_text' do
       subject { view.requests[0][:request_headers_text] }
 
-      context 'when charset=utf-8 is present' do
-        it "just strips that because it's the default for json" do
-          expect(subject).to eq "Content-Type: application/json\n            Another: header; charset=utf-8"
-        end
-      end
-
-      context 'when charset=utf-16 is present' do
-        let(:content_type) { "application/json; charset=utf-16" }
-
-        it "keeps that because it's NOT the default for json" do
-          expect(subject).to eq "Content-Type: application/json; charset=utf-16\n            Another: header; charset=utf-8"
+      context 'when Content-Type is present' do
+        it "removes it" do
+          expect(subject).to eq "Another: header; charset=utf-8"
         end
       end
     end
@@ -93,17 +85,9 @@ describe RspecApiDocumentation::Views::ApiBlueprintExample do
     describe 'response_headers_text' do
       subject { view.requests[0][:response_headers_text] }
 
-      context 'when charset=utf-8 is present' do
-        it "just strips that because it's the default for json" do
-          expect(subject).to eq "Content-Type: application/json\n            Another: header; charset=utf-8"
-        end
-      end
-
-      context 'when charset=utf-16 is present' do
-        let(:content_type) { "application/json; charset=utf-16" }
-
-        it "keeps that because it's NOT the default for json" do
-          expect(subject).to eq "Content-Type: application/json; charset=utf-16\n            Another: header; charset=utf-8"
+      context 'when Content-Type is present' do
+        it "removes it" do
+          expect(subject).to eq "Another: header; charset=utf-8"
         end
       end
     end

--- a/spec/views/api_blueprint_example_spec.rb
+++ b/spec/views/api_blueprint_example_spec.rb
@@ -59,7 +59,7 @@ describe RspecApiDocumentation::Views::ApiBlueprintExample do
 
       context 'when charset=utf-8 is present' do
         it "just strips that because it's the default for json" do
-          expect(subject).to eq "Content-Type: application/json\n        Another: header; charset=utf-8"
+          expect(subject).to eq "Content-Type: application/json\n            Another: header; charset=utf-8"
         end
       end
 
@@ -67,7 +67,7 @@ describe RspecApiDocumentation::Views::ApiBlueprintExample do
         let(:content_type) { "application/json; charset=utf-16" }
 
         it "keeps that because it's NOT the default for json" do
-          expect(subject).to eq "Content-Type: application/json; charset=utf-16\n        Another: header; charset=utf-8"
+          expect(subject).to eq "Content-Type: application/json; charset=utf-16\n            Another: header; charset=utf-8"
         end
       end
     end
@@ -95,7 +95,7 @@ describe RspecApiDocumentation::Views::ApiBlueprintExample do
 
       context 'when charset=utf-8 is present' do
         it "just strips that because it's the default for json" do
-          expect(subject).to eq "Content-Type: application/json\n        Another: header; charset=utf-8"
+          expect(subject).to eq "Content-Type: application/json\n            Another: header; charset=utf-8"
         end
       end
 
@@ -103,7 +103,7 @@ describe RspecApiDocumentation::Views::ApiBlueprintExample do
         let(:content_type) { "application/json; charset=utf-16" }
 
         it "keeps that because it's NOT the default for json" do
-          expect(subject).to eq "Content-Type: application/json; charset=utf-16\n        Another: header; charset=utf-8"
+          expect(subject).to eq "Content-Type: application/json; charset=utf-16\n            Another: header; charset=utf-8"
         end
       end
     end

--- a/spec/views/api_blueprint_index_spec.rb
+++ b/spec/views/api_blueprint_index_spec.rb
@@ -109,7 +109,7 @@ describe RspecApiDocumentation::Views::ApiBlueprintIndex do
 
         post_examples = post_route[:http_methods].map { |http_method| http_method[:examples] }.flatten
         expect(post_examples.size).to eq 2
-        expect(post_route[:route]).to eq "/posts/:id"
+        expect(post_route[:route]).to eq "/posts{/id}"
         expect(post_route[:route_name]).to eq "Single Post"
         expect(post_route[:has_parameters?]).to eq true
         expect(post_route[:parameters]).to eq [{
@@ -130,7 +130,7 @@ describe RspecApiDocumentation::Views::ApiBlueprintIndex do
 
         post_w_optionals_examples = post_route_with_optionals[:http_methods].map { |http_method| http_method[:examples] }.flatten
         expect(post_w_optionals_examples.size).to eq 1
-        expect(post_route_with_optionals[:route]).to eq "/posts/:id{?option=:option}"
+        expect(post_route_with_optionals[:route]).to eq "/posts{/id}{?option=:option}"
         expect(post_route_with_optionals[:route_name]).to eq "Single Post"
         expect(post_route_with_optionals[:has_parameters?]).to eq true
         expect(post_route_with_optionals[:parameters]).to eq [{

--- a/spec/views/api_blueprint_index_spec.rb
+++ b/spec/views/api_blueprint_index_spec.rb
@@ -109,7 +109,7 @@ describe RspecApiDocumentation::Views::ApiBlueprintIndex do
 
         post_examples = post_route[:http_methods].map { |http_method| http_method[:examples] }.flatten
         expect(post_examples.size).to eq 2
-        expect(post_route[:route]).to eq "/posts{/id}"
+        expect(post_route[:route]).to eq "/posts/{id}"
         expect(post_route[:route_name]).to eq "Single Post"
         expect(post_route[:has_parameters?]).to eq true
         expect(post_route[:parameters]).to eq [{
@@ -130,7 +130,7 @@ describe RspecApiDocumentation::Views::ApiBlueprintIndex do
 
         post_w_optionals_examples = post_route_with_optionals[:http_methods].map { |http_method| http_method[:examples] }.flatten
         expect(post_w_optionals_examples.size).to eq 1
-        expect(post_route_with_optionals[:route]).to eq "/posts{/id}{?option=:option}"
+        expect(post_route_with_optionals[:route]).to eq "/posts/{id}{?option=:option}"
         expect(post_route_with_optionals[:route_name]).to eq "Single Post"
         expect(post_route_with_optionals[:has_parameters?]).to eq true
         expect(post_route_with_optionals[:parameters]).to eq [{

--- a/spec/views/api_blueprint_index_spec.rb
+++ b/spec/views/api_blueprint_index_spec.rb
@@ -63,7 +63,10 @@ describe RspecApiDocumentation::Views::ApiBlueprintIndex do
 
   let(:rspec_example_comments) do
     comment_group.route "/comments", "Comments Collection" do
+      explanation "Route explanation"
+
       get("/comments") do
+        explanation "Method explanation"
         example_request 'Get all comments' do
         end
       end
@@ -98,6 +101,8 @@ describe RspecApiDocumentation::Views::ApiBlueprintIndex do
         post_route = sections[1][:routes][1]
         post_route_with_optionals = sections[1][:routes][2]
 
+        expect(comments_route[:explanation]).to eq "Route explanation"
+
         comments_examples = comments_route[:http_methods].map { |http_method| http_method[:examples] }.flatten
         expect(comments_examples.size).to eq 1
         expect(comments_route[:route]).to eq "/comments"
@@ -118,7 +123,7 @@ describe RspecApiDocumentation::Views::ApiBlueprintIndex do
           example: "1",
           name: "id",
           description: "The id",
-          properties_description: "required, string"
+          properties_description: "string, required"
         }]
         expect(post_route[:has_attributes?]).to eq true
         expect(post_route[:attributes]).to eq [{
@@ -139,11 +144,11 @@ describe RspecApiDocumentation::Views::ApiBlueprintIndex do
           example: "1",
           name: "id",
           description: "The id",
-          properties_description: "required, string"
+          properties_description: "string, required"
         }, {
           name: "option",
           description: nil,
-          properties_description: nil
+          properties_description: "optional"
         }]
         expect(post_route_with_optionals[:has_attributes?]).to eq false
         expect(post_route_with_optionals[:attributes]).to eq []
@@ -159,7 +164,7 @@ describe RspecApiDocumentation::Views::ApiBlueprintIndex do
           required: false,
           name: "description",
           description: nil,
-          properties_description: nil
+          properties_description: "optional"
         }]
       end
     end

--- a/templates/rspec_api_documentation/api_blueprint_index.mustache
+++ b/templates/rspec_api_documentation/api_blueprint_index.mustache
@@ -1,4 +1,4 @@
-FORMAT: A1
+FORMAT: 1A
 {{# sections }}
 
 # Group {{ resource_name }}

--- a/templates/rspec_api_documentation/api_blueprint_index.mustache
+++ b/templates/rspec_api_documentation/api_blueprint_index.mustache
@@ -22,8 +22,8 @@ FORMAT: 1A
 description: {{ description }}
 {{/ description }}
 {{# explanation }}
+{{{ explanation }}}
 
-explanation: {{ explanation }}
 {{/ explanation }}
 {{# has_parameters? }}
 

--- a/templates/rspec_api_documentation/api_blueprint_index.mustache
+++ b/templates/rspec_api_documentation/api_blueprint_index.mustache
@@ -42,11 +42,20 @@ description: {{ description }}
 {{# http_methods }}
 
 ### {{ description }} [{{ http_method }}]
+
+{{# explanation }}
+{{{ explanation }}}
+{{/ explanation }}
+
 {{# examples }}
 {{# requests }}
 {{# has_request? }}
 
 + Request {{ description }}{{# request_content_type }} ({{ request_content_type }}){{/ request_content_type }}
+
+    {{# explanation }}
+    {{{ explanation }}}
+    {{/ explanation }}
 {{/ has_request? }}
 {{# request_headers_text }}
 

--- a/templates/rspec_api_documentation/api_blueprint_index.mustache
+++ b/templates/rspec_api_documentation/api_blueprint_index.mustache
@@ -48,7 +48,11 @@ FORMAT: 1A
 + Parameters
 
 {{# attributes }}
-    + {{ name }}{{# properties_description }} ({{ properties_description }}){{/ properties_description }}{{# description }} - {{ description }}{{/ description }}
+    + {{ name }}{{# value }}: {{ value }}{{/ value }}{{# properties_description }} ({{ properties_description }}){{/ properties_description }}{{# description }} - {{ description }}{{/ description }}
+{{# default }}
+
+        + Default: {{ default }}
+{{/ default }}
 {{/ attributes }}
 {{/ has_attributes? }}
 {{# has_request? }}

--- a/templates/rspec_api_documentation/api_blueprint_index.mustache
+++ b/templates/rspec_api_documentation/api_blueprint_index.mustache
@@ -30,7 +30,7 @@ FORMAT: 1A
 + Parameters
 
 {{# parameters }}
-    + {{ name }}{{# example }}: {{ example }}{{/ example }}{{# properties_description }} ({{ properties_description }}){{/ properties_description }}{{# description }} - {{ description }}{{/ description }}
+    + {{ name }}{{# example }}: {{{ example }}}{{/ example }}{{# properties_description }} ({{ properties_description }}){{/ properties_description }}{{# description }} - {{ description }}{{/ description }}
 {{/ parameters }}
 {{/ has_parameters? }}
 {{# http_methods }}
@@ -45,13 +45,9 @@ FORMAT: 1A
 + Parameters
 
 {{# attributes }}
-    + {{ name }}{{# example }}: {{ example }}{{/ example }}{{# properties_description }} ({{ properties_description }}){{/ properties_description }}{{# description }} - {{ description }}{{/ description }}
+    + {{ name }}{{# example }}: {{{ example }}}{{/ example }}{{# properties_description }} ({{ properties_description }}){{/ properties_description }}{{# description }} - {{ description }}{{/ description }}
 {{/ attributes }}
 {{/ has_attributes? }}
-{{# explanation }}
-
-{{{ explanation }}}
-{{/ explanation }}
 
 {{# examples }}
 {{# requests }}

--- a/templates/rspec_api_documentation/api_blueprint_index.mustache
+++ b/templates/rspec_api_documentation/api_blueprint_index.mustache
@@ -30,7 +30,11 @@ FORMAT: 1A
 + Parameters
 
 {{# parameters }}
-    + {{ name }}{{# properties_description }} ({{ properties_description }}){{/ properties_description }}{{# description }} - {{ description }}{{/ description }}
+    + {{ name }}{{# properties_description }} ({{ properties_description }}){{/ properties_description }}
+{{# description }}
+
+        {{ description }}
+{{/ description }}
 {{/ parameters }}
 {{/ has_parameters? }}
 {{# http_methods }}
@@ -48,7 +52,11 @@ FORMAT: 1A
 + Parameters
 
 {{# attributes }}
-    + {{ name }}{{# value }}: {{ value }}{{/ value }}{{# properties_description }} ({{ properties_description }}){{/ properties_description }}{{# description }} - {{ description }}{{/ description }}
+    + {{ name }}{{# value }}: {{ value }}{{/ value }}{{# properties_description }} ({{ properties_description }}){{/ properties_description }}
+{{# description }}
+
+        {{ description }}
+{{/ description }}
 {{# default }}
 
         + Default: {{ default }}

--- a/templates/rspec_api_documentation/api_blueprint_index.mustache
+++ b/templates/rspec_api_documentation/api_blueprint_index.mustache
@@ -35,14 +35,14 @@ FORMAT: 1A
 {{/ has_parameters? }}
 {{# http_methods }}
 
-{{# examples }}
-{{# requests }}
-
-### {{ action_name }} [{{ http_method }}]
+### {{ description }} [{{ http_method }}]
 {{# explanation }}
 
 {{{ explanation }}}
 {{/ explanation }}
+
+{{# examples }}
+{{# requests }}
 {{# has_attributes? }}
 
 + Parameters

--- a/templates/rspec_api_documentation/api_blueprint_index.mustache
+++ b/templates/rspec_api_documentation/api_blueprint_index.mustache
@@ -1,5 +1,8 @@
 FORMAT: 1A
+
 # {{ api_name }}
+{{{ api_explanation }}}
+
 {{# sections }}
 
 # Group {{ resource_name }}

--- a/templates/rspec_api_documentation/api_blueprint_index.mustache
+++ b/templates/rspec_api_documentation/api_blueprint_index.mustache
@@ -19,11 +19,11 @@ FORMAT: 1A
 ## {{ route_name }} [{{ route }}]
 {{# description }}
 
-description: {{ description }}
+{{ description }}
 {{/ description }}
 {{# explanation }}
-{{{ explanation }}}
 
+{{{ explanation }}}
 {{/ explanation }}
 {{# has_parameters? }}
 
@@ -36,6 +36,10 @@ description: {{ description }}
 {{# http_methods }}
 
 ### {{ description }} [{{ http_method }}]
+{{# explanation }}
+
+{{{ explanation }}}
+{{/ explanation }}
 {{# has_attributes? }}
 
 + Parameters

--- a/templates/rspec_api_documentation/api_blueprint_index.mustache
+++ b/templates/rspec_api_documentation/api_blueprint_index.mustache
@@ -30,12 +30,13 @@ FORMAT: 1A
 + Parameters
 
 {{# parameters }}
-    + {{ name }}{{# example }}: {{{ example }}}{{/ example }}{{# properties_description }} ({{ properties_description }}){{/ properties_description }}{{# description }} - {{ description }}{{/ description }}
+    + {{ name }}{{# properties_description }} ({{ properties_description }}){{/ properties_description }}{{# description }} - {{ description }}{{/ description }}
 {{/ parameters }}
 {{/ has_parameters? }}
 {{# http_methods }}
 
 {{# examples }}
+{{# requests }}
 
 ### {{ action_name }} [{{ http_method }}]
 {{# explanation }}
@@ -47,11 +48,9 @@ FORMAT: 1A
 + Parameters
 
 {{# attributes }}
-    + {{ name }}{{# example }}: {{{ example }}}{{/ example }}{{# properties_description }} ({{ properties_description }}){{/ properties_description }}{{# description }} - {{ description }}{{/ description }}
+    + {{ name }}{{# properties_description }} ({{ properties_description }}){{/ properties_description }}{{# description }} - {{ description }}{{/ description }}
 {{/ attributes }}
 {{/ has_attributes? }}
-
-{{# requests }}
 {{# has_request? }}
 
 + Request {{ description }}{{# request_content_type }} ({{ request_content_type }}){{/ request_content_type }}

--- a/templates/rspec_api_documentation/api_blueprint_index.mustache
+++ b/templates/rspec_api_documentation/api_blueprint_index.mustache
@@ -28,22 +28,24 @@ description: {{ description }}
 {{# has_parameters? }}
 
 + Parameters
+
 {{# parameters }}
-  + {{ name }}{{# example }}: {{ example }}{{/ example }}{{# properties_description }} ({{ properties_description }}){{/ properties_description }}{{# description }} - {{ description }}{{/ description }}
+    + {{ name }}{{# example }}: {{ example }}{{/ example }}{{# properties_description }} ({{ properties_description }}){{/ properties_description }}{{# description }} - {{ description }}{{/ description }}
 {{/ parameters }}
 {{/ has_parameters? }}
-{{# has_attributes? }}
-
-+ Attributes (object)
-{{# attributes }}
-  + {{ name }}{{# example }}: {{ example }}{{/ example }}{{# properties_description }} ({{ properties_description }}){{/ properties_description }}{{# description }} - {{ description }}{{/ description }}
-{{/ attributes }}
-{{/ has_attributes? }}
 {{# http_methods }}
 
 ### {{ description }} [{{ http_method }}]
+{{# has_attributes? }}
 
++ Parameters
+
+{{# attributes }}
+    + {{ name }}{{# example }}: {{ example }}{{/ example }}{{# properties_description }} ({{ properties_description }}){{/ properties_description }}{{# description }} - {{ description }}{{/ description }}
+{{/ attributes }}
+{{/ has_attributes? }}
 {{# explanation }}
+
 {{{ explanation }}}
 {{/ explanation }}
 

--- a/templates/rspec_api_documentation/api_blueprint_index.mustache
+++ b/templates/rspec_api_documentation/api_blueprint_index.mustache
@@ -1,4 +1,5 @@
 FORMAT: 1A
+# {{ api_name }}
 {{# sections }}
 
 # Group {{ resource_name }}
@@ -48,13 +49,13 @@ explanation: {{ explanation }}
 
     + Headers
 
-        {{{ request_headers_text }}}
+            {{{ request_headers_text }}}
 {{/ request_headers_text }}
 {{# request_body }}
 
     + Body
 
-        {{{ request_body }}}
+            {{{ request_body }}}
 {{/ request_body }}
 {{# has_response? }}
 
@@ -64,13 +65,13 @@ explanation: {{ explanation }}
 
     + Headers
 
-        {{{ response_headers_text }}}
+            {{{ response_headers_text }}}
 {{/ response_headers_text }}
 {{# response_body }}
 
     + Body
 
-        {{{ response_body }}}
+            {{{ response_body }}}
 {{/ response_body }}
 {{/ requests }}
 {{/ examples }}

--- a/templates/rspec_api_documentation/api_blueprint_index.mustache
+++ b/templates/rspec_api_documentation/api_blueprint_index.mustache
@@ -35,7 +35,9 @@ FORMAT: 1A
 {{/ has_parameters? }}
 {{# http_methods }}
 
-### {{ description }} [{{ http_method }}]
+{{# examples }}
+
+### {{ action_name }} [{{ http_method }}]
 {{# explanation }}
 
 {{{ explanation }}}
@@ -49,7 +51,6 @@ FORMAT: 1A
 {{/ attributes }}
 {{/ has_attributes? }}
 
-{{# examples }}
 {{# requests }}
 {{# has_request? }}
 


### PR DESCRIPTION
I'm keeping this PR inside the FinalCAD organization for now because it's not completely ready yet and I'll add comments related to `Finalcloud`.
Feel free to make a PR against https://github.com/zipmark/rspec_api_documentation when it'll be finished.

The goal of this PR is to fix the `rspec_api_documentation` gem regarding the generation of documentation targeting the [API Blueprint](https://apiblueprint.org/) format.
[Apiary](https://app.apiary.io) was used to spot the errors in the generated file.

The API Blueprint Language Specification is available [here](https://github.com/apiaryio/api-blueprint/blob/format-1A/API%20Blueprint%20Specification.md). I targeted format 1A.

Here's what was fixed so far:
- There was a typo on the value of the metadata describing the format (cf. https://github.com/apiaryio/api-blueprint/blob/format-1A/API%20Blueprint%20Specification.md#41-metadata-section)
- Some sections were wrongly indented (cf. https://github.com/apiaryio/api-blueprint/blob/format-1A/API%20Blueprint%20Specification.md#ActionResponseSection)
- The API name wasn't present (cf. https://github.com/apiaryio/api-blueprint/blob/format-1A/API%20Blueprint%20Specification.md#42-api-name--overview-section)
- The variable parts in the URL were not correctly formated (cf. https://github.com/apiaryio/api-blueprint/blob/format-1A/API%20Blueprint%20Specification.md#431-resource-section and https://tools.ietf.org/html/rfc6570#section-3.2.6)

Some errors remain when we generate documentation with these fixes:
- [x] duplicate definition of 'Content-Type' header (Fixed in b57259d)
- [ ] parameter 'foo' is not found within the URI template '/bar/baz' for 'Route name'

Both are warnings. The second one is more important than the first one because the parameters are not correctly described.

1. ~~The "duplicate definition" one shouldn't be too complicated. It occurs because the media type is defined both in the [Resource Model Section](https://github.com/apiaryio/api-blueprint/blob/format-1A/API%20Blueprint%20Specification.md#4313-resource-model-section) and in the Headers. For example:~~ (Fixed in b57259d)
```
+ Request Get Work Element (application/json)

    + Headers

            Accept: application/x-finalcad-api-v3.6+json
            Content-Type: application/json
            Host: rollout.finalcad.fr
```

2. The "parameter 'foo' is not found within the URI template" one is more complicated. In all the other formats of `rspec_api_documentation`, query parameters are described by using the `parameter` method, be it an url parameter (for example `id` in `/users/:id`) or a parameter sent in the request body.
But for the API Blueprint format, there's a distinction. URL parameters are described with the `parameter` method but body parameters are described using the `attribute` method.
If we use the `parameter` method to describe an attribute, we have a warning because we describe a parameter which is not present in the URL.
This means that in our spec on `finalcloud`, we'll have to change all the description of attributes using the `parameter` method and replace it by the `attribute` one (there's no difference between both methods signatures so we'll just have to replace it where we need and keep `parameter` when it's an URL parameter).
The problem in the gem is that it only sends parameters described with the `parameter` method and not the other ones.
The following code will work and send `{"team": {"id": "d2988ee2-23b1-4573-8724-e2e8b94b8c84"}}` in the body.
```
route "api/projects/:project_id/teams.json", "Create Team" do
    post "Create Team" do
      parameter :id, "Uuid of the Team (uuid)", required: true, scope: :team

      let(:id) { 'd2988ee2-23b1-4573-8724-e2e8b94b8c84' }
# ...
```
But if we replace `parameter` by `attribute`, the body will be empty.
To fix this, we'll need to allow attributes to be added to the body when they're defined with the `attribute` method. We might also need to consider them as parameters in the other formats, otherwise they might not be displayed.